### PR TITLE
Handle zero-duration events in timeline construction and update processing/tests

### DIFF
--- a/src/eboa/engine/engine.py
+++ b/src/eboa/engine/engine.py
@@ -2481,9 +2481,22 @@ class Engine():
             # Sort list
             filtered_timeline_points.sort()
 
+            events_duration_0 = [event for event in events if event.start == event.stop]
+            events_duration_0_added_stop = {}
+            for event in events_duration_0:
+                # Insert only once the stop of the events with duration 0
+                if event.stop not in events_duration_0_added_stop:
+                    events_duration_0_added_stop[event.stop] = None
+                    filtered_timeline_points.append(event.stop)
+                # end if
+            # end for
+
+            # Sort list again after adding duplicated timestamps for events with duration 0
+            filtered_timeline_points.sort()
+
             events_per_timestamp = get_events_per_timestamp(events, filtered_timeline_points)
 
-            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points)
+            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points, events_duration_0)
 
             # Iterate through the periods
             next_timestamp = 1
@@ -2739,9 +2752,22 @@ class Engine():
             # Sort list
             filtered_timeline_points.sort()
 
+            events_duration_0 = [event for event in events if event.start == event.stop]
+            events_duration_0_added_stop = {}
+            for event in events_duration_0:
+                # Insert only once the stop of the events with duration 0
+                if event.stop not in events_duration_0_added_stop:
+                    events_duration_0_added_stop[event.stop] = None
+                    filtered_timeline_points.append(event.stop)
+                # end if
+            # end for
+
+            # Sort list again after adding duplicated timestamps for events with duration 0
+            filtered_timeline_points.sort()
+
             events_per_timestamp = get_events_per_timestamp(events, filtered_timeline_points)
 
-            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points)
+            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points, events_duration_0)
 
             # Iterate through the periods
             next_timestamp = 1
@@ -3017,9 +3043,22 @@ class Engine():
             # Sort list
             filtered_timeline_points.sort()
 
+            events_duration_0 = [event for event in events if event.start == event.stop]
+            events_duration_0_added_stop = {}
+            for event in events_duration_0:
+                # Insert only once the stop of the events with duration 0
+                if event.stop not in events_duration_0_added_stop:
+                    events_duration_0_added_stop[event.stop] = None
+                    filtered_timeline_points.append(event.stop)
+                # end if
+            # end for
+
+            # Sort list again after adding duplicated timestamps for events with duration 0
+            filtered_timeline_points.sort()
+
             events_per_timestamp = get_events_per_timestamp(events, filtered_timeline_points)
 
-            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points)
+            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points, events_duration_0)
 
             # Iterate through the periods
             next_timestamp = 1
@@ -3326,9 +3365,22 @@ class Engine():
             # Sort list
             filtered_timeline_points.sort()
 
+            events_duration_0 = [event for event in events if event.start == event.stop]
+            events_duration_0_added_stop = {}
+            for event in events_duration_0:
+                # Insert only once the stop of the events with duration 0
+                if event.stop not in events_duration_0_added_stop:
+                    events_duration_0_added_stop[event.stop] = None
+                    filtered_timeline_points.append(event.stop)
+                # end if
+            # end for
+
+            # Sort list again after adding duplicated timestamps for events with duration 0
+            filtered_timeline_points.sort()
+
             events_per_timestamp = get_events_per_timestamp(events, filtered_timeline_points)
 
-            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points)
+            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points, events_duration_0)
 
             # Iterate through the periods
             next_timestamp = 1
@@ -3582,9 +3634,22 @@ class Engine():
             # Sort list
             filtered_timeline_points.sort()
 
+            events_duration_0 = [event for event in events if event.start == event.stop]
+            events_duration_0_added_stop = {}
+            for event in events_duration_0:
+                # Insert only once the stop of the events with duration 0
+                if event.stop not in events_duration_0_added_stop:
+                    events_duration_0_added_stop[event.stop] = None
+                    filtered_timeline_points.append(event.stop)
+                # end if
+            # end for
+
+            # Sort list again after adding duplicated timestamps for events with duration 0
+            filtered_timeline_points.sort()
+
             events_per_timestamp = get_events_per_timestamp(events, filtered_timeline_points)
 
-            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points)
+            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points, events_duration_0)
 
             # Iterate through the periods
             next_timestamp = 1
@@ -3856,9 +3921,22 @@ class Engine():
             # Sort list
             filtered_timeline_points.sort()
 
+            events_duration_0 = [event for event in events if event.start == event.stop]
+            events_duration_0_added_stop = {}
+            for event in events_duration_0:
+                # Insert only once the stop of the events with duration 0
+                if event.stop not in events_duration_0_added_stop:
+                    events_duration_0_added_stop[event.stop] = None
+                    filtered_timeline_points.append(event.stop)
+                # end if
+            # end for
+
+            # Sort list again after adding duplicated timestamps for events with duration 0
+            filtered_timeline_points.sort()
+
             events_per_timestamp = get_events_per_timestamp(events, filtered_timeline_points)
 
-            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points)
+            sources_per_timestamp = get_sources_per_timestamp(sources, filtered_timeline_points, events_duration_0)
 
             # Iterate through the periods
             next_timestamp = 1

--- a/src/tests/test_insert_events_insert_and_erase_at_dim_level.py
+++ b/src/tests/test_insert_events_insert_and_erase_at_dim_level.py
@@ -1078,6 +1078,40 @@ class TestInsertEventsInsertAndEraseAtDim(unittest.TestCase):
 
         assert len(events) == 2
 
+    def test_insert_event_insert_and_erase_at_dim_signature_level_events_duration_0_at_the_beginning_to_stay(self):
+
+        data = {"operations": [{
+            "mode": "insert_and_erase",
+            "dim_signature": {"name": "dim_signature",
+                              "exec": "exec",
+                              "version": "1.0"},
+            "source": {"name": "source1.json",
+                       "reception_time": "2018-06-06T13:33:29",
+                       "generation_time": "2016-07-04T02:07:03",
+                       "validity_start": "2018-06-05T04:07:03",
+                       "validity_stop": "2018-06-05T06:07:03"},
+            "events": [{
+                "explicit_reference": "EXPLICIT_REFERENCE_EVENT",
+                "gauge": {"name": "GAUGE_NAME",
+                          "system": "GAUGE_SYSTEM",
+                          "insertion_type": "INSERT_and_ERASE"},
+                "start": "2018-06-05T04:07:03",
+                "stop": "2018-06-05T04:07:03"
+            }]
+        }]}
+        exit_status = self.engine_eboa.treat_data(data)
+
+        assert len([item for item in exit_status if item["status"] != eboa_engine.exit_codes["OK"]["status"]]) == 0
+
+        events = self.query_eboa.get_events()
+
+        assert len(events) == 1
+
+        events = self.query_eboa.get_events(start_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}],
+                                            stop_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}])
+
+        assert len(events) == 1
+
     def test_insert_event_insert_and_erase_at_dim_signature_level_event_duration_0_in_the_middle_of_events_to_remove(self):
 
         data1 = {"operations": [{

--- a/src/tests/test_insert_events_insert_and_erase_at_event_level.py
+++ b/src/tests/test_insert_events_insert_and_erase_at_event_level.py
@@ -283,7 +283,41 @@ class TestInsertEventsInsertAndEraseAtEvent(unittest.TestCase):
         events = self.session.query(Event).filter(Event.visible == True).all()
 
         assert len(events) == 3
-        
+
+    def test_insert_event_insert_and_erase_event_duration_0_at_the_beginning_to_stay(self):
+
+        data = {"operations": [{
+            "mode": "insert",
+            "dim_signature": {"name": "dim_signature",
+                              "exec": "exec",
+                              "version": "1.0"},
+            "source": {"name": "source1.json",
+                       "reception_time": "2018-06-06T13:33:29",
+                       "generation_time": "2016-07-04T02:07:03",
+                       "validity_start": "2018-06-05T04:07:03",
+                       "validity_stop": "2018-06-05T06:07:03"},
+            "events": [{
+                "explicit_reference": "EXPLICIT_REFERENCE_EVENT",
+                "gauge": {"name": "GAUGE_NAME",
+                          "system": "GAUGE_SYSTEM",
+                          "insertion_type": "INSERT_and_ERASE"},
+                "start": "2018-06-05T04:07:03",
+                "stop": "2018-06-05T04:07:03"
+            }]
+        }]}
+        exit_status = self.engine_eboa.treat_data(data)
+
+        assert len([item for item in exit_status if item["status"] != eboa_engine.exit_codes["OK"]["status"]]) == 0
+
+        events = self.query_eboa.get_events()
+
+        assert len(events) == 1
+
+        events = self.query_eboa.get_events(start_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}],
+                                            stop_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}])
+
+        assert len(events) == 1
+
     def test_insert_event_insert_and_erase_partial_remove_with_links(self):
 
         data1 = {"operations": [{

--- a/src/tests/test_insert_events_insert_and_erase_with_equal_or_lower_priority_at_dim_level.py
+++ b/src/tests/test_insert_events_insert_and_erase_with_equal_or_lower_priority_at_dim_level.py
@@ -279,6 +279,41 @@ class TestInsertEventsInsertAndEraseWithEqualOrLowerPriorityAtDim(unittest.TestC
 
         assert len(events) == 1
 
+    def test_insert_event_insert_and_erase_with_equal_or_lower_priority_at_dim_signature_level_events_duration_0_at_the_beginning_to_stay(self):
+
+        data = {"operations": [{
+            "mode": "insert_and_erase_with_equal_or_lower_priority",
+            "dim_signature": {"name": "dim_signature",
+                              "exec": "exec",
+                              "version": "1.0"},
+            "source": {"name": "source1.json",
+                       "reception_time": "2018-06-06T13:33:29",
+                       "generation_time": "2016-07-04T02:07:03",
+                       "validity_start": "2018-06-05T04:07:03",
+                       "validity_stop": "2018-06-05T06:07:03",
+                       "priority": "20"},
+            "events": [{
+                "explicit_reference": "EXPLICIT_REFERENCE_EVENT",
+                "gauge": {"name": "GAUGE_NAME",
+                          "system": "GAUGE_SYSTEM",
+                          "insertion_type": "SIMPLE_UPDATE"},
+                "start": "2018-06-05T04:07:03",
+                "stop": "2018-06-05T04:07:03"
+            }]
+        }]}
+        exit_status = self.engine_eboa.treat_data(data)
+
+        assert len([item for item in exit_status if item["status"] != eboa_engine.exit_codes["OK"]["status"]]) == 0
+
+        events = self.query_eboa.get_events()
+
+        assert len(events) == 1
+
+        events = self.query_eboa.get_events(start_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}],
+                                            stop_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}])
+
+        assert len(events) == 1
+
     def test_insert_and_erase_with_equal_or_lower_priority_at_dim_signature_level_with_split_event_at_the_end(self):
 
         data = {"operations": [{

--- a/src/tests/test_insert_events_insert_and_erase_with_equal_or_lower_priority_at_event_level.py
+++ b/src/tests/test_insert_events_insert_and_erase_with_equal_or_lower_priority_at_event_level.py
@@ -572,6 +572,41 @@ class TestInsertEventsInsertAndEraseWithEqualOrLowerPriorityAtEvent(unittest.Tes
 
         assert len(events) == 3
 
+    def test_insert_event_insert_and_erase_with_equal_or_lower_priority_event_duration_0_at_the_beginning_to_stay(self):
+
+        data = {"operations": [{
+            "mode": "insert",
+            "dim_signature": {"name": "dim_signature",
+                              "exec": "exec",
+                              "version": "1.0"},
+            "source": {"name": "source1.json",
+                       "reception_time": "2018-06-06T13:33:29",
+                       "generation_time": "2016-07-04T02:07:03",
+                       "validity_start": "2018-06-05T04:07:03",
+                       "validity_stop": "2018-06-05T06:07:03",
+                       "priority": "20"},
+            "events": [{
+                "explicit_reference": "EXPLICIT_REFERENCE_EVENT",
+                "gauge": {"name": "GAUGE_NAME",
+                          "system": "GAUGE_SYSTEM",
+                          "insertion_type": "INSERT_and_ERASE_with_EQUAL_or_LOWER_PRIORITY"},
+                "start": "2018-06-05T04:07:03",
+                "stop": "2018-06-05T04:07:03"
+            }]
+        }]}
+        exit_status = self.engine_eboa.treat_data(data)
+
+        assert len([item for item in exit_status if item["status"] != eboa_engine.exit_codes["OK"]["status"]]) == 0
+
+        events = self.query_eboa.get_events()
+
+        assert len(events) == 1
+
+        events = self.query_eboa.get_events(start_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}],
+                                            stop_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}])
+
+        assert len(events) == 1
+
     def test_insert_event_insert_and_erase_with_equal_or_lower_priority_partial_remove_with_links(self):
 
         data1 = {"operations": [{

--- a/src/tests/test_insert_events_insert_and_erase_with_priority_at_dim_level.py
+++ b/src/tests/test_insert_events_insert_and_erase_with_priority_at_dim_level.py
@@ -279,6 +279,41 @@ class TestInsertEventsInsertAndEraseWithPriorityAtDim(unittest.TestCase):
 
         assert len(events) == 1
 
+    def test_insert_event_insert_and_erase_with_priority_at_dim_signature_level_events_duration_0_at_the_beginning_to_stay(self):
+
+        data = {"operations": [{
+            "mode": "insert_and_erase_with_priority",
+            "dim_signature": {"name": "dim_signature",
+                              "exec": "exec",
+                              "version": "1.0"},
+            "source": {"name": "source1.json",
+                       "reception_time": "2018-06-06T13:33:29",
+                       "generation_time": "2016-07-04T02:07:03",
+                       "validity_start": "2018-06-05T04:07:03",
+                       "validity_stop": "2018-06-05T06:07:03",
+                       "priority": "20"},
+            "events": [{
+                "explicit_reference": "EXPLICIT_REFERENCE_EVENT",
+                "gauge": {"name": "GAUGE_NAME",
+                          "system": "GAUGE_SYSTEM",
+                          "insertion_type": "SIMPLE_UPDATE"},
+                "start": "2018-06-05T04:07:03",
+                "stop": "2018-06-05T04:07:03"
+            }]
+        }]}
+        exit_status = self.engine_eboa.treat_data(data)
+
+        assert len([item for item in exit_status if item["status"] != eboa_engine.exit_codes["OK"]["status"]]) == 0
+
+        events = self.query_eboa.get_events()
+
+        assert len(events) == 1
+
+        events = self.query_eboa.get_events(start_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}],
+                                            stop_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}])
+
+        assert len(events) == 1
+
     def test_insert_and_erase_with_priority_at_dim_signature_level_with_split_event_at_the_end(self):
 
         data = {"operations": [{

--- a/src/tests/test_insert_events_insert_and_erase_with_priority_at_event_level.py
+++ b/src/tests/test_insert_events_insert_and_erase_with_priority_at_event_level.py
@@ -865,6 +865,41 @@ class TestInsertEventsInsertAndEraseWithPriorityAtEvent(unittest.TestCase):
 
         assert len(events) == 3
 
+    def test_insert_event_insert_and_erase_with_priority_event_duration_0_at_the_beginning_to_stay(self):
+
+        data = {"operations": [{
+            "mode": "insert",
+            "dim_signature": {"name": "dim_signature",
+                              "exec": "exec",
+                              "version": "1.0"},
+            "source": {"name": "source1.json",
+                       "reception_time": "2018-06-06T13:33:29",
+                       "generation_time": "2016-07-04T02:07:03",
+                       "validity_start": "2018-06-05T04:07:03",
+                       "validity_stop": "2018-06-05T06:07:03",
+                       "priority": "20"},
+            "events": [{
+                "explicit_reference": "EXPLICIT_REFERENCE_EVENT",
+                "gauge": {"name": "GAUGE_NAME",
+                          "system": "GAUGE_SYSTEM",
+                          "insertion_type": "INSERT_and_ERASE_with_PRIORITY"},
+                "start": "2018-06-05T04:07:03",
+                "stop": "2018-06-05T04:07:03"
+            }]
+        }]}
+        exit_status = self.engine_eboa.treat_data(data)
+
+        assert len([item for item in exit_status if item["status"] != eboa_engine.exit_codes["OK"]["status"]]) == 0
+
+        events = self.query_eboa.get_events()
+
+        assert len(events) == 1
+
+        events = self.query_eboa.get_events(start_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}],
+                                            stop_filters = [{"date": "2018-06-05T04:07:03", "op": "=="}])
+
+        assert len(events) == 1
+
     def test_insert_event_insert_and_erase_with_priority_partial_remove_with_links(self):
 
         data1 = {"operations": [{


### PR DESCRIPTION
### Motivation
- Fix incorrect processing of events where `start == stop` that were not being included in the timeline, which could cause zero-duration events to be removed or ignored during insert/erase flows.
- Ensure timeline and source/event alignment accounts for zero-duration events so removals/splits operate correctly across all insertion modes.

### Description
- When building `filtered_timeline_points` in `Engine`, collect `events_duration_0 = [event for event in events if event.start == event.stop]` and append their `stop` timestamps to the timeline, then re-sort the timeline.
- Pass `events_duration_0` into `get_sources_per_timestamp` where the function is called so source selection can be aware of zero-duration events.
- Apply the same changes in each relevant processing block inside `src/eboa/engine/engine.py` to ensure consistent handling across all code paths.
- Add multiple unit tests that exercise insert/erase flows with zero-duration events at the beginning of validity ranges across different insertion modes and priority variants.

### Testing
- Added unit tests in `test_insert_events_insert_and_erase_at_dim_level.py`, `test_insert_events_insert_and_erase_at_event_level.py`, `test_insert_events_insert_and_erase_with_equal_or_lower_priority_at_dim_level.py`, `test_insert_events_insert_and_erase_with_equal_or_lower_priority_at_event_level.py`, `test_insert_events_insert_and_erase_with_priority_at_dim_level.py`, and `test_insert_events_insert_and_erase_with_priority_at_event_level.py` that assert zero-duration events at the beginning of validity windows are preserved.
- Ran the test suite including the new tests (unit tests invoking `engine_eboa.treat_data` and `query_eboa.get_events`) and the updated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfee9996f08330b28032389fc36c7e)